### PR TITLE
fix(test): Java 테스트 연습의 오류 수정 및 assertEquals 인자 순서를 올바르게 변경

### DIFF
--- a/java-test/complete/src/test/java/woowacourse/JUnit5Test.java
+++ b/java-test/complete/src/test/java/woowacourse/JUnit5Test.java
@@ -365,8 +365,8 @@ public class JUnit5Test {
                     () -> assertEquals(21, 7 * 3),
                     () -> assertEquals(16, 7 * 3 ^ 5),
                     () -> assertEquals(5, 7 * 3 / 5 + 33 / 21),
-                    () -> assertEquals(23, 33 * 3 / 5 + 7 / 2),
-                    () -> assertEquals(22, 33 * 3 / 5 + 7 / 2 + 1)
+                    () -> assertEquals(22, 33 * 3 / 5 + 7 / 2),
+                    () -> assertEquals(23, 33 * 3 / 5 + 7 / 2 + 1)
             );
 
         }

--- a/java-test/complete/src/test/java/woowacourse/JUnit5Test.java
+++ b/java-test/complete/src/test/java/woowacourse/JUnit5Test.java
@@ -360,13 +360,13 @@ public class JUnit5Test {
         @DisplayName("assertAll 메서드로 여러 검증 코드를 한 번에 실행한다")
         void assertAll_메서드로_여러_검증_코드를_한_번에_실행한다() {
             assertAll(
-                    () -> assertEquals(1 + 2, 3),
-                    () -> assertEquals(2 + 3, 5),
-                    () -> assertEquals(7 * 3, 21),
-                    () -> assertEquals(7 * 3 ^ 5, 16),
-                    () -> assertEquals(7 * 3 / 5 + 33 / 21, 5),
-                    () -> assertEquals(33 * 3 / 5 + 7 / 2, 23),
-                    () -> assertEquals(33 * 3 / 5 + 7 / 2 + 1, 22)
+                    () -> assertEquals(3, 1 + 2),
+                    () -> assertEquals(5, 2 + 3),
+                    () -> assertEquals(21, 7 * 3),
+                    () -> assertEquals(16, 7 * 3 ^ 5),
+                    () -> assertEquals(5, 7 * 3 / 5 + 33 / 21),
+                    () -> assertEquals(23, 33 * 3 / 5 + 7 / 2),
+                    () -> assertEquals(22, 33 * 3 / 5 + 7 / 2 + 1)
             );
 
         }

--- a/java-test/initial/src/test/java/woowacourse/AssertJTest.java
+++ b/java-test/initial/src/test/java/woowacourse/AssertJTest.java
@@ -48,7 +48,7 @@ public class AssertJTest {
             final var expected = 3;
 
             // TODO: JUnit5의 assertEquals 메서드를 AssertJ의 isEqualTo 메서드로 변경해보세요.
-            assertEquals(actual, expected);
+            assertEquals(expected, actual);
         }
 
         /**
@@ -63,10 +63,10 @@ public class AssertJTest {
             final var b = 2;
             final var actual = a + b;
 
-            final var expected = 4;
+            final var unexpected = 4;
 
             // TODO: JUnit5의 assertNotEquals 메서드를 AssertJ의 isNotEqualTo 메서드로 변경해보세요.
-            assertNotEquals(actual, expected);
+            assertNotEquals(unexpected, actual);
         }
 
         /**
@@ -109,7 +109,7 @@ public class AssertJTest {
             final var expected = actual;
 
             // TODO: JUnit5의 assertSame 메서드를 AssertJ의 isSameAs 메서드로 변경해보세요.
-            assertSame(actual, expected);
+            assertSame(expected, actual);
         }
 
         /**
@@ -121,10 +121,10 @@ public class AssertJTest {
         @DisplayName("isNotSameAs 메서드로 두 객체가 같은 객체인지 비교한다")
         void isNotSameAs_메서드로_두_객체가_같은_객체인지_비교한다() {
             final var actual = new Object();
-            final var expected = new Object();
+            final var unexpected = new Object();
 
             // TODO: JUnit5의 assertNotSame 메서드를 AssertJ의 isNotSameAs 메서드로 변경해보세요.
-            assertNotSame(actual, expected);
+            assertNotSame(unexpected, actual);
         }
 
         /*
@@ -279,7 +279,7 @@ public class AssertJTest {
             final var expected = 3;
 
             // TODO: AssertJ의 기능을 활용하여 Collection의 크기를 비교해보세요.
-            assertEquals(actual.size(), expected);
+            assertEquals(expected, actual.size());
         }
 
         /**
@@ -306,7 +306,7 @@ public class AssertJTest {
 
             // TODO: AssertJ의 기능을 활용하여 Collection에 특정 객체들이 포함되어 있는지 비교해보세요.
             for (int i = 0, end = actual.size(); i < end; i++) {
-                assertEquals(actual.get(i), expected.get(i));
+                assertEquals(expected.get(i), actual.get(i));
             }
 
             /* ----- 아래는 추가로 학습할 분만 보세요! -----
@@ -355,7 +355,7 @@ public class AssertJTest {
 
             // TODO: AssertJ의 extracting 메서드를 사용하여 actual에 포함된 User 객체들 중 username 필드를 추출하여 expected와 비교해보세요.
             for (int i = 0, end = actual.size(); i < end; i++) {
-                assertEquals(actual.get(i).getUsername(), expected.get(i));
+                assertEquals(expected.get(i), actual.get(i).getUsername());
             }
 
             /* ----- 아래는 추가로 학습할 분만 보세요! -----

--- a/java-test/initial/src/test/java/woowacourse/JUnit5Test.java
+++ b/java-test/initial/src/test/java/woowacourse/JUnit5Test.java
@@ -364,13 +364,13 @@ public class JUnit5Test {
         @DisplayName("assertAll 메서드로 여러 검증 코드를 한 번에 실행한다")
         void assertAll_메서드로_여러_검증_코드를_한_번에_실행한다() {
             // TODO: `assertAll`을 사용하지 않고 모든 테스트를 통과시키는 것과 `assertAll`를 사용하고 모든 테스트를 통과시키는 것에 차이를 비교해보세요.
-            assertEquals(1 + 2, 3);
-            assertEquals(2 + 3, 5);
-            assertEquals(7 * 3, 21);
-            assertEquals(7 * 3 ^ 5, 32);
-            assertEquals(7 * 3 / 5 + 33 / 21, 4);
-            assertEquals(33 * 3 / 5 + 7 / 2, 22);
-            assertEquals(33 * 3 / 5 + 7 / 2 + 1, 22);
+            assertEquals(3, 1 + 2);
+            assertEquals(5, 3 + 2);
+            assertEquals(21, 7 * 3);
+            assertEquals(32, 3 * 7 ^ 5);
+            assertEquals(4, 7 * 3 / 5 + 33 / 21);
+            assertEquals(22, 33 * 3 / 5 + 7 / 2);
+            assertEquals(22, 33 * 3 / 5 + 7 / 2 + 1);
         }
     }
 


### PR DESCRIPTION
안녕하세요, 6기 아루(이동훈)입니다. 제공해주신 테스트 학습 덕분에 두 테스트 라이브러리의 차이점에 대해서 배워나가고 있습니다, 고맙습니다 😁
다만 몇몇 부분이 의도대로 표현되지 않은 것 같아 PR을 남깁니다. 한 번 확인해주시면 감사하겠습니다!

### 수정사항
- `JUnit5`의 `assertEquals`의 파라미터 순서에 맞게 인자의 순서를 수정
- 같지 않은 것을 검증하는 `assertNotEquals` 등에 전달되는 변수명을 `unexpected`로 수정
- `complete`의 `JUnit5Test`의 `assertAll` 부분에서, 내부 수식이 올바르지 않아 테스트에 실패하는 곳을 올바르게 수정