### PR TITLE
fix(java-test): assertThat 설명 변경

### DIFF
--- a/java-test/initial/src/test/java/woowacourse/AssertJTest.java
+++ b/java-test/initial/src/test/java/woowacourse/AssertJTest.java
@@ -28,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class AssertJTest {
     /**
-     * AssertJ의 `assertThat` 메서드는 JUnit5의 `assertThat` 메서드와 비슷한 기능을 합니다.
+     * AssertJ의 `assertThat` 메서드는 다양한 Assert 타입을 반환하도록 오버로딩 되어있습니다.
+     * Assert에서 제공되는 다양한 메서드를 이용해 값을 검증할 수 있습니다.
      */
     @Nested
     @DisplayName("assertThat 메서드 학습 테스트")


### PR DESCRIPTION
Junit5에 `assertThat`이 없기 때문에 assertJ의 assertThat 메서드를 소개하는 부분을 변경했습니다.